### PR TITLE
升级ons-client版本，解决maven拉取不到jar包问题

### DIFF
--- a/spring/java-spring-demo/pom.xml
+++ b/spring/java-spring-demo/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.aliyun.openservices</groupId>
             <artifactId>ons-client</artifactId>
-            <version>1.7.2.Final</version>
+            <version>1.7.9.Final</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
update ons-client to 1.7.9